### PR TITLE
Add branch trigger for master-test in workflow

### DIFF
--- a/.github/workflows/Demo.ReadVersion.yml
+++ b/.github/workflows/Demo.ReadVersion.yml
@@ -4,6 +4,7 @@ on:
   push:
     branches:
       - master  # Runs only on push events to the master branch
+      - master-test  # Runs on push events to the master-test branch
 
 jobs:
   extract-version:


### PR DESCRIPTION
Add branch trigger for master-test in workflow

Updated `Demo.ReadVersion.yml` to include a trigger for the
`master-test` branch, enabling the workflow to run on push
events for both `master` and `master-test` branches.